### PR TITLE
Initialize docs and skeleton agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# Agentic-AI-Based-Culture-Fit-Interview-
+# Agentic AI-Based Culture Fit Interview Simulator
+
+This repository aims to build an **Agentic AI-powered Culture Fit Interview Simulator**. The system uses a multi-agent architecture with Retrieval-Augmented Generation (RAG) to assess a candidate's cultural alignment and provide coaching feedback.
+
+## Objectives
+- Build a web platform for uploading candidate data (resume, LinkedIn, personal statement) and company cultural documents or URLs.
+- Integrate an Agentic AI workflow in a single RAG-enabled agent for retrieving cultural cues.
+- Implement multiple specialized agents to handle candidate profiling, question generation, response evaluation, and coaching.
+- Store profiles, questions, evaluations, and feedback in a database.
+- Ensure explainable, unbiased scoring with sentiment analysis.
+
+## System Architecture
+1. **Company Culture Retriever Agent**
+   - Uses RAG to extract cultural cues from documents or websites.
+   - Accepts PDF, DOCX, text, or URLs and outputs structured JSON.
+2. **Candidate Profile Agent**
+   - Processes resumes, LinkedIn profiles, and personal statements to build a candidate profile.
+   - Handles multiple input formats and outputs structured JSON.
+3. **Question Generator Agent**
+   - Generates adaptive culture-fit interview questions based on cultural cues and candidate profile.
+4. **Response Evaluator Agent**
+   - Scores candidate responses for alignment with company values and provides feedback.
+5. **Response Coaching Agent**
+   - Offers actionable suggestions to improve candidate answers.
+
+## Example Flow
+1. Upload company and candidate data via the frontend.
+2. The Company Culture Retriever Agent produces cultural cues JSON.
+3. The Candidate Profile Agent builds a candidate profile JSON.
+4. The Question Generator Agent produces tailored interview questions.
+5. The Response Evaluator Agent assesses responses and assigns scores.
+6. The Response Coaching Agent provides feedback and suggestions.
+7. The UI displays questions, evaluation scores, and coaching advice.
+
+See the `docs/` directory for a detailed specification of each agent and acceptance criteria.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,44 @@
+# Agentic AI-Based Culture Fit Interview Simulator
+
+This document outlines the architecture and agent responsibilities for the culture fit interview simulator.
+
+## Agents and Responsibilities
+
+### 1. Company Culture Retriever Agent
+- **Function**: Extract cultural cues and values from company documents or URLs.
+- **Input**: PDF, DOCX, text files, or website URLs.
+- **Output**: Structured JSON with labeled cultural elements.
+- **Acceptance Criteria**:
+  - Extract at least 80% of relevant cultural information.
+  - Handle multiple input formats and filter irrelevant content.
+  - Process inputs in under one minute.
+
+### 2. Candidate Profile Agent
+- **Function**: Build a candidate profile from resume, LinkedIn, and personal statement.
+- **Input**: Resume (PDF/DOCX), LinkedIn URL, personal statement text.
+- **Output**: Structured JSON with skills, experience, achievements, and values.
+- **Acceptance Criteria**:
+  - Extract at least 80% of relevant fields.
+  - Handle multiple input formats and remove noise.
+  - Process five profiles in under two minutes.
+
+### 3. Question Generator Agent
+- **Function**: Generate adaptive interview questions aligned with company culture and candidate profile.
+- **Input**: Cultural cues JSON and candidate profile JSON.
+- **Output**: At least five tailored questions.
+
+### 4. Response Evaluator Agent
+- **Function**: Score candidate responses for alignment, sentiment, and relevance.
+- **Input**: Candidate responses, cultural cues JSON, and questions.
+- **Output**: Evaluation report with a numeric score and specific feedback.
+
+### 5. Response Coaching Agent
+- **Function**: Provide real-time suggestions to improve candidate answers.
+- **Input**: Candidate responses, evaluation report, and cultural cues JSON.
+- **Output**: Actionable coaching feedback.
+
+## Data Storage
+All candidate profiles, questions, evaluations, and coaching feedback are stored in MongoDB for transparency and review.
+
+## Testing Considerations
+The project includes tests for cultural cue extraction, question relevance, evaluation consistency, and coaching effectiveness. Sample documents and candidate data should be used to validate the system.

--- a/src/agents.py
+++ b/src/agents.py
@@ -1,0 +1,54 @@
+"""Skeleton implementation for the Culture Fit Interview Simulator agents."""
+
+from dataclasses import dataclass
+from typing import List, Dict, Any
+
+
+@dataclass
+class CulturalCues:
+    values: Dict[str, Any]
+
+
+@dataclass
+class CandidateProfile:
+    data: Dict[str, Any]
+
+
+class CompanyCultureRetrieverAgent:
+    """Extract cultural cues from company documents or URLs."""
+
+    def retrieve(self, sources: List[str]) -> CulturalCues:
+        # TODO: implement RAG-based extraction
+        return CulturalCues(values={})
+
+
+class CandidateProfileAgent:
+    """Build a profile from resume, LinkedIn, and personal statement."""
+
+    def build_profile(self, resume_path: str, linkedin_url: str, statement: str) -> CandidateProfile:
+        # TODO: implement profile extraction
+        return CandidateProfile(data={})
+
+
+class QuestionGeneratorAgent:
+    """Generate culture-fit interview questions."""
+
+    def generate(self, cues: CulturalCues, profile: CandidateProfile) -> List[str]:
+        # TODO: implement adaptive question generation
+        return []
+
+
+class ResponseEvaluatorAgent:
+    """Evaluate candidate responses and score alignment."""
+
+    def evaluate(self, responses: List[str], cues: CulturalCues) -> Dict[str, Any]:
+        # TODO: implement response evaluation
+        return {}
+
+
+class ResponseCoachingAgent:
+    """Provide coaching feedback for candidate responses."""
+
+    def coach(self, responses: List[str], evaluation: Dict[str, Any], cues: CulturalCues) -> List[str]:
+        # TODO: implement coaching suggestions
+        return []

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,37 @@
+"""Entry point for running the culture fit interview simulator."""
+
+from agents import (
+    CompanyCultureRetrieverAgent,
+    CandidateProfileAgent,
+    QuestionGeneratorAgent,
+    ResponseEvaluatorAgent,
+    ResponseCoachingAgent,
+    CulturalCues,
+    CandidateProfile,
+)
+
+
+def run_example():
+    """Run an example workflow using placeholder data."""
+    retriever = CompanyCultureRetrieverAgent()
+    profile_agent = CandidateProfileAgent()
+    question_agent = QuestionGeneratorAgent()
+    evaluator = ResponseEvaluatorAgent()
+    coach = ResponseCoachingAgent()
+
+    # Placeholder inputs
+    cues = retriever.retrieve(["company_values.pdf"])
+    profile = profile_agent.build_profile("resume.pdf", "https://linkedin.com/in/example", "I value collaboration and innovation.")
+
+    questions = question_agent.generate(cues, profile)
+    responses = ["sample response"]
+    evaluation = evaluator.evaluate(responses, cues)
+    feedback = coach.coach(responses, evaluation, cues)
+
+    print("Questions:", questions)
+    print("Evaluation:", evaluation)
+    print("Coaching feedback:", feedback)
+
+
+if __name__ == "__main__":
+    run_example()


### PR DESCRIPTION
## Summary
- expand README with project outline
- add detailed architecture notes
- provide Python skeleton for agent classes and main entry point

## Testing
- `python -m py_compile src/agents.py src/main.py`
- `python src/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6854e33b5904832b8246fa4c7cd2def8