### PR TITLE
Add MongoDB backend and API integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-DATABASE_URL=sqlite:///data.db
+DATABASE_URL=mongodb+srv://vikramshanmugam2002:oQDDiwFyExNZ6b5D@cluster0.kotkjf5.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
 GEMINI_API_KEY=AIzaSyALeeFY7veBr8rHYSqwD5GyKyu7IGH0764

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository aims to build an **Agentic AI-powered Culture Fit Interview Simu
 - Build a web platform for uploading candidate data (resume, LinkedIn, personal statement) and company cultural documents or URLs.
 - Integrate an Agentic AI workflow in a single RAG-enabled agent for retrieving cultural cues.
 - Implement multiple specialized agents to handle candidate profiling, question generation, response evaluation, and coaching.
-- Store profiles, questions, evaluations, and feedback in a database.
+- Store profiles, questions, evaluations, and feedback in a MongoDB database.
 - Ensure explainable, unbiased scoring with sentiment analysis.
 
 ## System Architecture
@@ -33,3 +33,12 @@ This repository aims to build an **Agentic AI-powered Culture Fit Interview Simu
 7. The UI displays questions, evaluation scores, and coaching advice.
 
 See the `docs/` directory for a detailed specification of each agent and acceptance criteria.
+
+## Running the Backend
+
+Ensure a MongoDB instance is accessible. Update `DATABASE_URL` in `.env` or copy
+`.env.example` with the provided connection string. Then run:
+
+```bash
+uvicorn backend.app.main:app --reload
+```

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,9 +1,9 @@
-"""Simple database dependency."""
+"""MongoDB database connection utilities."""
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
+from pymongo import MongoClient
 
 from .settings import settings
 
-engine = create_engine(settings.database_url)
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+client = MongoClient(settings.database_url)
+
+db = client[settings.mongo_db_name]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,34 +1,13 @@
-"""Entry point for running the culture fit interview backend."""
+"""FastAPI application for the culture fit interview backend."""
 
-from .agents.culture_retriever import CompanyCultureRetrieverAgent
-from .agents.candidate_profile import CandidateProfileAgent
-from .agents.question_generator import QuestionGeneratorAgent
-from .agents.response_evaluator import ResponseEvaluatorAgent
-from .agents.response_coach import ResponseCoachingAgent
-from .agents.base import CulturalCues, CandidateProfile
+from fastapi import FastAPI
+
+from .routers import candidate, company, interview
 
 
-def run_example() -> None:
-    """Run an example workflow using placeholder data."""
-    retriever = CompanyCultureRetrieverAgent()
-    profile_agent = CandidateProfileAgent()
-    question_agent = QuestionGeneratorAgent()
-    evaluator = ResponseEvaluatorAgent()
-    coach = ResponseCoachingAgent()
+app = FastAPI(title="Culture Fit Interview API")
 
-    cues = retriever.retrieve(["company_values.pdf"])
-    profile = profile_agent.build_profile(
-        "resume.pdf", "https://linkedin.com/in/example", "I value collaboration"
-    )
-    questions = question_agent.generate(cues, profile)
-    responses = ["sample response"]
-    evaluation = evaluator.evaluate(responses, cues)
-    feedback = coach.coach(responses, evaluation, cues)
+app.include_router(candidate.router)
+app.include_router(company.router)
+app.include_router(interview.router)
 
-    print("Questions:", questions)
-    print("Evaluation:", evaluation)
-    print("Coaching feedback:", feedback)
-
-
-if __name__ == "__main__":
-    run_example()

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,7 +1,24 @@
-"""Database models placeholder."""
+"""Pydantic models for MongoDB documents."""
 
-from sqlalchemy.orm import DeclarativeBase
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
 
 
-class Base(DeclarativeBase):
-    pass
+class CandidateModel(BaseModel):
+    id: Optional[str] = Field(alias="_id", default=None)
+    profile: Dict[str, Any]
+
+
+class CompanyModel(BaseModel):
+    id: Optional[str] = Field(alias="_id", default=None)
+    cues: Dict[str, Any]
+
+
+class InterviewModel(BaseModel):
+    id: Optional[str] = Field(alias="_id", default=None)
+    candidate_id: str
+    company_id: str
+    questions: List[str]
+    evaluation: Dict[str, Any]
+    coaching: List[str]

--- a/backend/app/routers/candidate.py
+++ b/backend/app/routers/candidate.py
@@ -2,9 +2,20 @@
 
 from fastapi import APIRouter
 
+from ..agents.candidate_profile import CandidateProfileAgent
+from ..database import db
+from ..schemas import CandidateInput, CandidateOutput
+
+
 router = APIRouter()
 
 
-@router.post("/candidate")
-async def upload_candidate() -> dict:
-    return {"status": "received"}
+@router.post("/candidate", response_model=CandidateOutput)
+async def upload_candidate(data: CandidateInput) -> CandidateOutput:
+    """Build a candidate profile and store it in MongoDB."""
+    agent = CandidateProfileAgent()
+    profile = agent.build_profile(
+        data.resume_path, data.linkedin_url, data.personal_statement
+    )
+    result = db.candidates.insert_one(profile.data)
+    return CandidateOutput(id=str(result.inserted_id), profile=profile.data)

--- a/backend/app/routers/company.py
+++ b/backend/app/routers/company.py
@@ -2,9 +2,18 @@
 
 from fastapi import APIRouter
 
+from ..agents.culture_retriever import CompanyCultureRetrieverAgent
+from ..database import db
+from ..schemas import CompanyInput, CompanyOutput
+
+
 router = APIRouter()
 
 
-@router.post("/company")
-async def upload_company() -> dict:
-    return {"status": "received"}
+@router.post("/company", response_model=CompanyOutput)
+async def upload_company(data: CompanyInput) -> CompanyOutput:
+    """Extract cultural cues and store them in MongoDB."""
+    agent = CompanyCultureRetrieverAgent()
+    cues = agent.retrieve(data.sources)
+    result = db.companies.insert_one(cues.values)
+    return CompanyOutput(id=str(result.inserted_id), cues=cues.values)

--- a/backend/app/routers/interview.py
+++ b/backend/app/routers/interview.py
@@ -1,10 +1,46 @@
 """API routes for running interviews."""
 
-from fastapi import APIRouter
+from bson import ObjectId
+from fastapi import APIRouter, HTTPException
+
+from ..agents.base import CandidateProfile, CulturalCues
+from ..agents.question_generator import QuestionGeneratorAgent
+from ..agents.response_coach import ResponseCoachingAgent
+from ..agents.response_evaluator import ResponseEvaluatorAgent
+from ..database import db
+from ..schemas import InterviewInput, InterviewOutput
+
 
 router = APIRouter()
 
 
-@router.post("/interview")
-async def start_interview() -> dict:
-    return {"questions": []}
+@router.post("/interview", response_model=InterviewOutput)
+async def start_interview(data: InterviewInput) -> InterviewOutput:
+    """Run the interview process and store results."""
+    candidate = db.candidates.find_one({"_id": ObjectId(data.candidate_id)})
+    company = db.companies.find_one({"_id": ObjectId(data.company_id)})
+    if not candidate or not company:
+        raise HTTPException(status_code=404, detail="Candidate or company not found")
+
+    profile = CandidateProfile(data=candidate)
+    cues = CulturalCues(values=company)
+
+    q_agent = QuestionGeneratorAgent()
+    questions = q_agent.generate(cues, profile)
+
+    evaluator = ResponseEvaluatorAgent()
+    evaluation = evaluator.evaluate(data.responses, cues)
+
+    coach = ResponseCoachingAgent()
+    coaching = coach.coach(data.responses, evaluation, cues)
+
+    doc = {
+        "candidate_id": data.candidate_id,
+        "company_id": data.company_id,
+        "questions": questions,
+        "evaluation": evaluation,
+        "coaching": coaching,
+    }
+    result = db.interviews.insert_one(doc)
+    doc["id"] = str(result.inserted_id)
+    return InterviewOutput(**doc)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,7 +1,38 @@
-"""Pydantic schemas placeholder."""
+"""Pydantic request and response schemas."""
+
+from typing import Any, Dict, List
 
 from pydantic import BaseModel
 
 
-class ExampleSchema(BaseModel):
-    message: str
+class CandidateInput(BaseModel):
+    resume_path: str
+    linkedin_url: str
+    personal_statement: str
+
+
+class CandidateOutput(BaseModel):
+    id: str
+    profile: Dict[str, Any]
+
+
+class CompanyInput(BaseModel):
+    sources: List[str]
+
+
+class CompanyOutput(BaseModel):
+    id: str
+    cues: Dict[str, Any]
+
+
+class InterviewInput(BaseModel):
+    candidate_id: str
+    company_id: str
+    responses: List[str]
+
+
+class InterviewOutput(BaseModel):
+    id: str
+    questions: List[str]
+    evaluation: Dict[str, Any]
+    coaching: List[str]

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -4,7 +4,12 @@ from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
-    database_url: str = "sqlite:///data.db"
+    """Environment settings."""
+
+    database_url: str = (
+        "mongodb+srv://vikramshanmugam2002:oQDDiwFyExNZ6b5D@cluster0.kotkjf5.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0"
+    )
+    mongo_db_name: str = "culture_fit"
 
 
 settings = Settings()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,8 +1,8 @@
 fastapi
 uvicorn
-sqlalchemy
 pydantic
 requests
 beautifulsoup4
 pdfplumber
 python-docx
+pymongo


### PR DESCRIPTION
## Summary
- switch backend to MongoDB using provided connection string
- implement Pydantic models and request/response schemas
- add FastAPI routes for candidate, company, and interview workflows
- update settings and requirements
- document running the backend with MongoDB

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855035628e0832baa795cda615a75d7