### PR TITLE
Add basic React frontend for data uploads and interview

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,15 +1,55 @@
-import React from 'react';
+import React, { useState } from 'react';
 import UploadCompany from './pages/UploadCompany.jsx';
 import UploadCandidate from './pages/UploadCandidate.jsx';
 import Interview from './pages/Interview.jsx';
+import Dashboard from './pages/Dashboard.jsx';
+import Preferences from './pages/Preferences.jsx';
+
+/**
+ * Simple single page navigation. This avoids the need for
+ * react-router which is not included in this minimal setup.
+ */
+
+const PAGES = {
+  uploadCompany: 'Upload Company',
+  uploadCandidate: 'Upload Candidate',
+  interview: 'Interview',
+  dashboard: 'Dashboard',
+  preferences: 'Preferences',
+};
 
 export default function App() {
+  const [page, setPage] = useState(PAGES.uploadCompany);
+  const [interviewResult, setInterviewResult] = useState(null);
+
+  let content = null;
+  if (page === PAGES.uploadCompany) content = <UploadCompany />;
+  if (page === PAGES.uploadCandidate) content = <UploadCandidate />;
+  if (page === PAGES.interview)
+    content = (
+      <Interview
+        onComplete={(data) => {
+          setInterviewResult(data);
+          setPage(PAGES.dashboard);
+        }}
+      />
+    );
+  if (page === PAGES.dashboard)
+    content = <Dashboard data={interviewResult} />;
+  if (page === PAGES.preferences) content = <Preferences />;
+
   return (
     <div>
       <h1>Culture Fit Interview</h1>
-      <UploadCompany />
-      <UploadCandidate />
-      <Interview />
+      <nav>
+        {Object.entries(PAGES).map(([key, label]) => (
+          <button key={key} onClick={() => setPage(label)} disabled={page === label}>
+            {label}
+          </button>
+        ))}
+      </nav>
+      <hr />
+      {content}
     </div>
   );
 }

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -1,5 +1,8 @@
+const BASE_URL = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000';
+
 export async function post(path, data) {
-  const res = await fetch(path, {
+  const url = BASE_URL + path;
+  const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data),

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+export default function Dashboard({ data }) {
+  if (!data) return (
+    <section>
+      <h2>Dashboard</h2>
+      <p>No interview run yet.</p>
+    </section>
+  );
+
+  return (
+    <section>
+      <h2>Dashboard</h2>
+      <div>
+        <h3>Questions</h3>
+        <ol>
+          {data.questions.map((q, i) => (
+            <li key={i}>{q}</li>
+          ))}
+        </ol>
+      </div>
+      <div>
+        <h3>Evaluation</h3>
+        <pre>{JSON.stringify(data.evaluation, null, 2)}</pre>
+      </div>
+      <div>
+        <h3>Coaching Feedback</h3>
+        <ul>
+          {data.coaching.map((c, i) => (
+            <li key={i}>{c}</li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/pages/Interview.jsx
+++ b/frontend/src/pages/Interview.jsx
@@ -1,9 +1,65 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { post } from '../api.js';
 
-export default function Interview() {
+export default function Interview({ onComplete }) {
+  const [form, setForm] = useState({
+    candidate_id: '',
+    company_id: '',
+    responses: '',
+  });
+  const [result, setResult] = useState(null);
+
+  const handleChange = (e) =>
+    setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const payload = {
+      candidate_id: form.candidate_id,
+      company_id: form.company_id,
+      responses: form.responses
+        .split('\n')
+        .map((s) => s.trim())
+        .filter(Boolean),
+    };
+    const data = await post('/interview', payload);
+    setResult(data);
+    if (onComplete) onComplete(data);
+  };
+
   return (
     <section>
       <h2>Interview</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <input
+            name="candidate_id"
+            placeholder="Candidate ID"
+            value={form.candidate_id}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <input
+            name="company_id"
+            placeholder="Company ID"
+            value={form.company_id}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <textarea
+            name="responses"
+            placeholder="Candidate responses, one per line"
+            value={form.responses}
+            onChange={handleChange}
+          />
+        </div>
+        <button type="submit">Run Interview</button>
+      </form>
+      {result && (
+        <pre>{JSON.stringify(result, null, 2)}</pre>
+      )}
     </section>
   );
 }

--- a/frontend/src/pages/Preferences.jsx
+++ b/frontend/src/pages/Preferences.jsx
@@ -1,0 +1,37 @@
+import React, { useState, useEffect } from 'react';
+
+/**
+ * Simple user control panel for evaluation preferences. For now the
+ * preferences are stored in localStorage so they persist between reloads.
+ */
+export default function Preferences() {
+  const [threshold, setThreshold] = useState(0.5);
+
+  useEffect(() => {
+    const saved = localStorage.getItem('evaluationThreshold');
+    if (saved) setThreshold(parseFloat(saved));
+  }, []);
+
+  const handleChange = (e) => {
+    const val = parseFloat(e.target.value);
+    setThreshold(val);
+    localStorage.setItem('evaluationThreshold', val);
+  };
+
+  return (
+    <section>
+      <h2>Evaluation Preferences</h2>
+      <label>
+        Passing score threshold: {threshold}
+        <input
+          type="range"
+          min="0"
+          max="1"
+          step="0.1"
+          value={threshold}
+          onChange={handleChange}
+        />
+      </label>
+    </section>
+  );
+}

--- a/frontend/src/pages/UploadCandidate.jsx
+++ b/frontend/src/pages/UploadCandidate.jsx
@@ -1,9 +1,54 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { post } from '../api.js';
 
 export default function UploadCandidate() {
+  const [form, setForm] = useState({
+    resume_path: '',
+    linkedin_url: '',
+    personal_statement: '',
+  });
+  const [candidateId, setCandidateId] = useState(null);
+
+  const handleChange = (e) =>
+    setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const data = await post('/candidate', form);
+    setCandidateId(data.id);
+  };
+
   return (
     <section>
       <h2>Upload Candidate Data</h2>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <input
+            name="resume_path"
+            placeholder="Resume file path"
+            value={form.resume_path}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <input
+            name="linkedin_url"
+            placeholder="LinkedIn URL"
+            value={form.linkedin_url}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <textarea
+            name="personal_statement"
+            placeholder="Personal statement"
+            value={form.personal_statement}
+            onChange={handleChange}
+          />
+        </div>
+        <button type="submit">Submit</button>
+      </form>
+      {candidateId && <p>Candidate saved with id: {candidateId}</p>}
     </section>
   );
 }

--- a/frontend/src/pages/UploadCompany.jsx
+++ b/frontend/src/pages/UploadCompany.jsx
@@ -1,9 +1,32 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { post } from '../api.js';
 
 export default function UploadCompany() {
+  const [sources, setSources] = useState('');
+  const [companyId, setCompanyId] = useState(null);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const list = sources
+      .split('\n')
+      .map((s) => s.trim())
+      .filter(Boolean);
+    const data = await post('/company', { sources: list });
+    setCompanyId(data.id);
+  };
+
   return (
     <section>
       <h2>Upload Company Data</h2>
+      <form onSubmit={handleSubmit}>
+        <textarea
+          value={sources}
+          onChange={(e) => setSources(e.target.value)}
+          placeholder="Enter document paths or URLs, one per line"
+        />
+        <button type="submit">Submit</button>
+      </form>
+      {companyId && <p>Company saved with id: {companyId}</p>}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- build React single-page navigation without react-router
- implement candidate and company upload forms
- add interview page that posts to backend and shows results
- include dashboard and preferences panels
- set base URL for API requests

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_685509775a9c832b997a33e893c6aff8