### PR TITLE
Add CORS middleware to FastAPI app

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,11 +1,20 @@
 """FastAPI application for the culture fit interview backend."""
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 
 from .routers import candidate, company, interview
 
 
 app = FastAPI(title="Culture Fit Interview API")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 app.include_router(candidate.router)
 app.include_router(company.router)


### PR DESCRIPTION
## Summary
- allow CORS by importing CORSMiddleware and adding middleware configuration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685513565e00832b8ec66f3fb13d0aee