### PR TITLE
Fix skill section parsing

### DIFF
--- a/backend/app/agents/candidate_profile.py
+++ b/backend/app/agents/candidate_profile.py
@@ -69,7 +69,8 @@ class CandidateProfileAgent(BaseAgent):
             if not line:
                 continue
             if re.search(r"^skills?[:\-]", lower):
-                skills.extend(re.split(r",|;", line.split("", 1)[-1]))
+                skills_line = re.split(r"[:\-]", line, 1)[-1]
+                skills.extend(re.split(r",|;", skills_line))
             elif "experience" in lower:
                 experience.append(line)
             elif "achievement" in lower or "accomplish" in lower:


### PR DESCRIPTION
## Summary
- correctly split the skills line in CandidateProfileAgent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685513589f70832b8a7acfd1f5c0d9fe