### PR TITLE
Use env var for MongoDB URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-DATABASE_URL=mongodb+srv://vikramshanmugam2002:oQDDiwFyExNZ6b5D@cluster0.kotkjf5.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+DATABASE_URL=mongodb://localhost:27017
 GEMINI_API_KEY=AIzaSyALeeFY7veBr8rHYSqwD5GyKyu7IGH0764

--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ This repository aims to build an **Agentic AI-powered Culture Fit Interview Simu
 
 See the `docs/` directory for a detailed specification of each agent and acceptance criteria.
 
+## Environment Variables
+
+The backend expects a MongoDB connection string provided via the
+`DATABASE_URL` environment variable. If not specified, it defaults to
+`mongodb://localhost:27017`. You can copy `.env.example` to `.env` and
+adjust the value as needed.
+
 ## Running the Backend
 
 Ensure a MongoDB instance is accessible. Update `DATABASE_URL` in `.env` or copy

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -1,13 +1,15 @@
 """Application settings for the backend."""
 
+import os
 from pydantic import BaseSettings
 
 
 class Settings(BaseSettings):
     """Environment settings."""
 
-    database_url: str = (
-        "mongodb+srv://vikramshanmugam2002:oQDDiwFyExNZ6b5D@cluster0.kotkjf5.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0"
+    database_url: str = os.getenv(
+        "DATABASE_URL",
+        "mongodb://localhost:27017",
     )
     mongo_db_name: str = "culture_fit"
 


### PR DESCRIPTION
## Summary
- read `DATABASE_URL` from the environment in backend settings
- document the `DATABASE_URL` variable in the README
- show a placeholder entry in `.env.example`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68551a1f142c832bb5eb43b4899badbb